### PR TITLE
Corruption Example/Test code

### DIFF
--- a/src/com/projectkorra/spirits/SpiritManager.java
+++ b/src/com/projectkorra/spirits/SpiritManager.java
@@ -9,6 +9,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import com.projectkorra.projectkorra.util.ParticleEffect;
+import com.projectkorra.spirits.ability.dark.Corruption;
 import com.projectkorra.spirits.spiritmob.DarkSpirit;
 import com.projectkorra.spirits.spiritmob.LightSpirit;
 
@@ -44,6 +45,12 @@ public class SpiritManager extends BukkitRunnable {
 				}
 			}
 		}
+		
+		for (Player p : Corruption.instances.keySet()) {
+			Corruption.instances.get(p).progress();
+		}
+		
+		//Corruption.revertAll();
 		
 	}
 	

--- a/src/com/projectkorra/spirits/ability/dark/Corruption.java
+++ b/src/com/projectkorra/spirits/ability/dark/Corruption.java
@@ -1,18 +1,39 @@
 package com.projectkorra.spirits.ability.dark;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 
+import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.util.TempBlock;
 import com.projectkorra.spirits.ability.DarkAbility;
 import com.projectkorra.spirits.configuration.ConfigManager;
 
 public class Corruption extends DarkAbility {
 	
-	static long cooldown = ConfigManager.getConfig().getLong("Abilities.Dark.Corruption.Cooldown");
-	static double range = ConfigManager.getConfig().getDouble("Abilities.Dark.Corruption.Range");
+	Material[] convertableTypes = {
+			Material.GRASS
+	};
 	
-	private double distanceTravelled;
-	private Location location;
+	public static ConcurrentHashMap<Player, Corruption> instances = new ConcurrentHashMap<Player, Corruption>();
+	public static List<Block> corruptedBlocks = new ArrayList<Block>();
+	
+	static long cooldown = ConfigManager.getConfig().getLong("Abilities.Dark.Corruption.Cooldown");
+	static double radius = ConfigManager.getConfig().getDouble("Abilities.Dark.Corruption.Radius");
+	static long warmup = ConfigManager.getConfig().getLong("Abilities.Dark.Corruption.WarmUp");
+	static long duration = ConfigManager.getConfig().getLong("Abilities.Dark.Corruption.Duration");
+	
+	private Location origin;
+	private boolean isFinished = false;
+	private boolean corrupted = false;
+	private List<TempBlock> tempBlocks = new ArrayList<TempBlock>();
+	private List<Block> affectedBlocks = new ArrayList<Block>();
 
 	public Corruption(Player player) {
 		super(player);
@@ -22,32 +43,75 @@ public class Corruption extends DarkAbility {
 			return;
 		}
 		
-		location = player.getEyeLocation();
+		if (instances.containsKey(player)) {
+			return;
+		}
+		
+		convert(player.getLocation());
+		instances.put(player, this);
 		bPlayer.addCooldown(this);
-		start();
+	}
+	
+	public void convert(Location origin) {
+		
+		this.origin = origin;
+		for (Block block : GeneralMethods.getBlocksAroundPoint(origin, radius)) {
+			if (Arrays.asList(convertableTypes).contains(block.getType())) {
+				affectedBlocks.add(block);
+			}
+		}
+	}
+	
+	public void execute() {
+		
+		for (Block block : affectedBlocks) {
+			
+			TempBlock tempBlock = new TempBlock(block, Material.MYCEL, (byte) 0);
+			tempBlocks.add(tempBlock);
+		}
+		
+		corrupted = true;
+	}
+	
+	public void revertCorruption() {
+		
+		for (TempBlock tempBlock : tempBlocks) {
+			tempBlock.revertBlock();
+		}
+		
+		tempBlocks.clear();
+	}
+	
+	public void remove() {
+		
+		revertCorruption();
+		instances.remove(player);
 	}
 
 	@Override
 	public void progress() {
+		
+		long currentTime = System.currentTimeMillis();
 		
 		if (player == null || !player.isOnline() || player.isDead()) {
 			remove();
 			return;
 		}
 		
-		if (!bPlayer.canBendIgnoreCooldowns(this)) {
+		if (isFinished) {
 			remove();
 			return;
 		}
 		
-		if (distanceTravelled >= range) {
-			remove();
-			return;
+		if (!isFinished && !corrupted && currentTime > startTime + warmup) {
+			
+			execute();
 		}
-		
-		player.sendMessage("Activate");
-		remove();
-		return;
+			
+		if (currentTime > startTime + duration) {
+			
+			isFinished = true;
+		}
 	}
 
 	@Override
@@ -57,7 +121,7 @@ public class Corruption extends DarkAbility {
 
 	@Override
 	public Location getLocation() {
-		return location;
+		return origin;
 	}
 
 	@Override

--- a/src/com/projectkorra/spirits/ability/dark/DarkBeam.java
+++ b/src/com/projectkorra/spirits/ability/dark/DarkBeam.java
@@ -10,10 +10,10 @@ import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ability.ElementalAbility;
 import com.projectkorra.projectkorra.util.DamageHandler;
 import com.projectkorra.projectkorra.util.ParticleEffect;
-import com.projectkorra.spirits.ability.SpiritAbility;
+import com.projectkorra.spirits.ability.DarkAbility;
 import com.projectkorra.spirits.configuration.ConfigManager;
 
-public class DarkBeam extends SpiritAbility {
+public class DarkBeam extends DarkAbility {
 	
 	static long cooldown = ConfigManager.getConfig().getLong("Abilities.Dark.DarkBeam.Cooldown");
 	static double range = ConfigManager.getConfig().getDouble("Abilities.Dark.DarkBeam.Range");

--- a/src/com/projectkorra/spirits/ability/dark/SoulRebirth.java
+++ b/src/com/projectkorra/spirits/ability/dark/SoulRebirth.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.bukkit.Location;
 import org.bukkit.Sound;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 
 import com.projectkorra.projectkorra.GeneralMethods;
@@ -120,13 +121,14 @@ public class SoulRebirth extends DarkAbility {
 		this.spawnTime = System.currentTimeMillis();
 		
 		for (int i = 0; i < amount; i++) {
-			ArrayList<Location> locations = SpiritMethods.getCircle(player.getLocation(), 3, 36);
-			int value = SpiritMethods.randomInteger(0, locations.size() - 1);
-			Location location = locations.get(value);
-			DarkSpirit darkSpirit = new DarkSpirit(location.getWorld());
-			SpiritType.spawnEntity(darkSpirit, location);
-			ParticleEffect.LARGE_SMOKE.display(location, 0, 0, 0, 0, 1);
-			location.getWorld().playSound(location, Sound.ENTITY_WITHER_SHOOT, 1, 0.1F);
+			
+			List<Block> blocks = GeneralMethods.getBlocksAroundPoint(player.getLocation(), 4);
+			int value = SpiritMethods.randomInteger(0, blocks.size() - 1);
+			Location location = GeneralMethods.getTopBlock(blocks.get(value).getLocation(), 4, 4).getLocation();
+			Location spawnPoint = location.clone().add(0, 1, 0);
+			DarkSpirit darkSpirit = new DarkSpirit(spawnPoint.getWorld());
+			SpiritType.spawnEntity(darkSpirit, spawnPoint);
+			location.getWorld().playSound(location, Sound.ENTITY_WITHER_SHOOT, 0.25F, 0.1F);
 			spirits.add(darkSpirit);
 		}
 	}

--- a/src/com/projectkorra/spirits/configuration/ConfigManager.java
+++ b/src/com/projectkorra/spirits/configuration/ConfigManager.java
@@ -63,7 +63,9 @@ public class ConfigManager {
 		
 		config.addDefault("Abilities.Dark.Corruption.Enabled", true);
 		config.addDefault("Abilities.Dark.Corruption.Cooldown", 1000);
-		config.addDefault("Abilities.Dark.Corruption.Range", 40);
+		config.addDefault("Abilities.Dark.Corruption.Radius", 10);
+		config.addDefault("Abilities.Dark.Corruption.WarmUp", 1000);
+		config.addDefault("Abilities.Dark.Corruption.Duration", 5000);
 		
 		config.addDefault("Abilities.Dark.SoulRebirth.Enabled", true);
 		config.addDefault("Abilities.Dark.SoulRebirth.Cooldown", 7000);


### PR DESCRIPTION
Corruption

* Added Corruption ability for Dark spirits.
* Only example code at the moment.

_________

DarkBeam

* Changed DarkBeam back to DarkAbility rather than SpiritAbility.

_________

SoulRebirth

* Fixed spawning for Dark spirits. They now spawn on the surface, rather than anywhere within the player's radius.

_________